### PR TITLE
Automatically reconnect MQTT client

### DIFF
--- a/custom_components/techlife_bulb/light.py
+++ b/custom_components/techlife_bulb/light.py
@@ -44,6 +44,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         client.username_pw_set(broker_username, broker_password)
 
         client.connect(broker_url, 1883, 60)
+        client.loop_start()
 
     except:
         _LOGGER.error(


### PR DESCRIPTION
TechLife component becomes non-functional
when the MQTT broker drops the connection.
To resolve the issue, enable reconnection
handling in the Paho MQTT client by
calling loop_start().